### PR TITLE
Change datetime to long for unix

### DIFF
--- a/Backend/Models/Message.cs
+++ b/Backend/Models/Message.cs
@@ -60,7 +60,7 @@
             _from = String.Empty;
             _to = String.Empty;
             _in = String.Empty;
-            _at = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
+            _at = 0;
             _with = String.Empty;
         }
 

--- a/Backend/Models/Message.cs
+++ b/Backend/Models/Message.cs
@@ -6,7 +6,7 @@
         public string From = "";
         public string To = "";
         public string In = "";
-        public DateTime At = DateTime.Now;
+        public long At = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
         public string With = "";
         public MessageParams(string rawString)
         {
@@ -29,10 +29,7 @@
                         In = commandPair[1];
                         break;
                     case "AT":
-                        long unixTimestamp = long.Parse(commandPair[1]);
-                        DateTimeOffset dateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
-                        DateTime dateTime = dateTimeOffset.UtcDateTime;
-                        At = dateTime;
+                        At = long.Parse(commandPair[1]);
                         break;
                     case "WITH":
                         With = rawString.Split("WITH\r\n", 2)[1];
@@ -54,7 +51,7 @@
         protected string _from;
         protected string _to;
         protected string _in;
-        protected DateTime _at;
+        protected long _at;
         protected string _with;
 
         protected Message()
@@ -63,7 +60,7 @@
             _from = String.Empty;
             _to = String.Empty;
             _in = String.Empty;
-            _at = DateTime.Now;
+            _at = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
             _with = String.Empty;
         }
 

--- a/Backend/Models/TextMessage.cs
+++ b/Backend/Models/TextMessage.cs
@@ -20,8 +20,8 @@ namespace Backend.Models
             set { _channel = value; }
         }
 
-        private DateTime _timestamp;
-        public DateTime TimeStamp
+        private long _timestamp;
+        public long TimeStamp
         {
             get { return _timestamp; }
             set { _timestamp = value; }
@@ -38,7 +38,7 @@ namespace Backend.Models
         {
             _sender = String.Empty;
             _channel = String.Empty;
-            _timestamp = DateTime.Now;
+            _timestamp = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
             _content = String.Empty;
         }
 

--- a/Backend/Models/TextMessage.cs
+++ b/Backend/Models/TextMessage.cs
@@ -38,7 +38,7 @@ namespace Backend.Models
         {
             _sender = String.Empty;
             _channel = String.Empty;
-            _timestamp = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
+            _timestamp = 0;
             _content = String.Empty;
         }
 

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,4 +1,3 @@
-using Backend;
 using Backend.Database;
 using Backend.ServerModules;
 using WebSocketSharp.Server;


### PR DESCRIPTION
- Changed timestamp variable data types from DateTime to long for storing Unix time
- Removed unused import in Program.cs

[Trello ticket](https://trello.com/c/X5eeUrXU/44-change-datetime-to-long-for-unix)