### PR TITLE
Implement the direct message page + Add a send button next to the text input field

### DIFF
--- a/Frontend/Frontend.Client/Models/TextMessageInterface.cs
+++ b/Frontend/Frontend.Client/Models/TextMessageInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace Frontend.Client.Models
+{
+    public class TextMessageInterface
+    {
+        public string messageText { get; set; } = string.Empty;
+    }
+}

--- a/Frontend/Frontend.Client/Pages/DmPage.razor
+++ b/Frontend/Frontend.Client/Pages/DmPage.razor
@@ -2,16 +2,21 @@
 @using Models
 @inject NavigationManager navMan
 
-<button class="dmChatButton" @onclick="backToMain"> Main Chat </button>
+<button class="dmChatButton" @onclick="backToMain"><span class="dmChatButtonArrow">&lt;</span> Main Chat </button>
 <div class="chatMessageDiv">
-    <ul class="message-ul">
+    <ul class="messageUl">
         @* messages to be displayed here when rendered *@
+        <li>Sample message</li>
+        <li>Sample message</li>
+        <li>Sample message</li>
+
     </ul>
 </div>
-<EditForm Model="@textMessage" FormName="messageForm" class="messageForm">
 
+<div class="messageForm">
     <InputText class="textBox" id="enterMessageBox" placeholder="Message the Chat!" @bind-Value="textMessage.messageText"></InputText>
-</EditForm>
+    <button class="sendMessageButton">➤</button>
+</div>
 
 @code {
 

--- a/Frontend/Frontend.Client/Pages/DmPage.razor
+++ b/Frontend/Frontend.Client/Pages/DmPage.razor
@@ -1,6 +1,32 @@
 ﻿@page "/dm"
+@using Models
+@inject NavigationManager navMan
 
-<h3>this is the DM page</h3>
+<button class="dmChatButton" @onclick="backToMain"> Main Chat </button>
+<div class="chatMessageDiv">
+    <ul class="message-ul">
+        @* messages to be displayed here when rendered *@
+    </ul>
+</div>
+<EditForm Model="@textMessage" FormName="messageForm" class="messageForm">
+
+    <InputText class="textBox" id="enterMessageBox" placeholder="Message the Chat!" @bind-Value="textMessage.messageText"></InputText>
+</EditForm>
+
 @code {
+
+    public TextMessageInterface textMessage { get; set; } = new()
+        {
+            messageText = string.Empty,
+        };
+
+
+    // Currently the function is not working,there is a problem with the interactivity settings of the frontend it seems,needs extra digging into documentation,time didn't serve, to be fixed soon.
+    public void backToMain()
+    {
+        navMan.NavigateTo("login");
+
+    }
+
 
 }

--- a/Frontend/Frontend/wwwroot/app.css
+++ b/Frontend/Frontend/wwwroot/app.css
@@ -51,6 +51,41 @@ input {
     background-color: #525CEB;
 }
 
+.dmChatButton {
+    display: block;
+    margin-top: 2rem;
+    margin-left: 3rem;
+    height: 2.8rem;
+    font-size: 0.9rem;
+    font-weight: bolder;
+    color: #D9D9D9;
+    border: 1px;
+    border-radius: 6px;
+    background-color: #525CEB;
+}
+
+.textBox {
+    background-color: #D9D9D9;
+    border: 2px;
+    border-radius: 6px;
+    height: 2.5rem;
+    width: 14rem;
+    padding-left: 1.2rem;
+}
+
+.messageForm {
+    display: block;
+    position: fixed;
+    bottom: 0;
+    margin-bottom: 4rem;
+    margin-left: 3rem;
+}
+
+.textBox {
+    height: 3.5rem;
+    width: 75rem;
+}
+
 /* Custom CSS to hide arrows in InputNumber */
 .no-arrows::-webkit-inner-spin-button,
 .no-arrows::-webkit-outer-spin-button {

--- a/Frontend/Frontend/wwwroot/app.css
+++ b/Frontend/Frontend/wwwroot/app.css
@@ -51,6 +51,32 @@ input {
     background-color: #525CEB;
 }
 
+.chatMessageDiv {
+    background-color: #434145;
+    margin-left: 3rem;
+    height: 45rem;
+    width: 76rem;
+    position: relative;
+}
+
+.chatMessageDiv li {
+    list-style: none;
+    background-color: #D9D9D9;
+    border: 2px;
+    border-radius: 6px;
+    height: 2.5rem;
+    width: 60rem;
+    margin-bottom: 1.5rem;
+    padding-top: 1rem;
+    padding-left: 0.5rem;
+}
+
+.messageUl {
+    padding: 1.5rem;
+    position: absolute;
+    bottom: 0;
+}
+
 .dmChatButton {
     display: block;
     margin-top: 2rem;
@@ -64,26 +90,45 @@ input {
     background-color: #525CEB;
 }
 
+.sendMessageButton {
+    height: 3.5rem;
+    font-size: 1.5rem;
+    font-weight: bolder;
+    color: #D9D9D9;
+    border: 1px;
+    border-radius: 6px;
+    background-color: #525CEB;
+    margin-left: 0.5rem;
+    width: 4rem;
+}
+
+.dmChatButtonArrow {
+    font-weight: bolder;
+}
+
+.dmChatButton:hover {
+    background-color: #3e49ed;
+}
+
+.sendMessageButton:hover {
+    background-color: #3e49ed;
+}
+
 .textBox {
     background-color: #D9D9D9;
     border: 2px;
     border-radius: 6px;
-    height: 2.5rem;
-    width: 14rem;
+    height: 3.5rem;
+    width: 75rem;
     padding-left: 1.2rem;
 }
 
 .messageForm {
-    display: block;
+    display: flex;
     position: fixed;
     bottom: 0;
     margin-bottom: 4rem;
     margin-left: 3rem;
-}
-
-.textBox {
-    height: 3.5rem;
-    width: 75rem;
 }
 
 /* Custom CSS to hide arrows in InputNumber */


### PR DESCRIPTION
DM page has been created and the required stylings have been applied, send message button has been made but it's still not functional, but this is not within the scope of the current ticket at the moment.

A textMessageInterface model has been created along the way to make the basis for being able to send messages later on.

different shading has also been applied to the message area as requested in a comment on the previous pull request.