### PR TITLE
Implement sender ip retrieval in the CommandMessage class

### DIFF
--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace Backend.Models.Messages
+﻿using Backend.Models.Users;
+
+namespace Backend.Models.Messages
 {
     enum CommandType
     {
@@ -14,7 +16,7 @@
     public class CommandMessage : Message
     {
         private CommandType _command;
-        private string _sender;
+        private User? _sender;
         private string? _target;
         private string? _channel;
         private string? _payload;
@@ -58,14 +60,13 @@
                     return CommandType.Unbanip;
                 default:
                     return CommandType.Unknown;
-
             }
         }
 
         public CommandMessage(string rawString) : base(rawString)
         {
             _command = GetCommandType();
-            _sender = _from;
+            _sender = UserManager.GetUserByUsername(_from);
             _target = _to;
             _channel = _in;
             _payload = _with;

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -28,7 +28,10 @@ namespace Backend.Models.Users
         {
             return user.Ip == "127.0.0.1";
         }
-        public static User? GetUserByUsername(string username) { return null; }
+        public static User? GetUserByUsername(string username) 
+        {
+            return UsersList.Find(user => user.Username == username);
+        }
         public static void Authenticate(WebSocket socket, string username) { }
         public static void Disconnect(User user) { }
         private static User? GetUserBySocket(WebSocket socket) { return null; }

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -24,6 +24,11 @@ namespace Backend.Models.Users
             return newUser;
         }
 
+        public static bool IsUserAdmin(User user) 
+        {
+            return user.Ip == "127.0.0.1";
+        }
+        public static User? GetUserByUsername(string username) { return null; }
         public static void Authenticate(WebSocket socket, string username) { }
         public static void Disconnect(User user) { }
         private static User? GetUserBySocket(WebSocket socket) { return null; }


### PR DESCRIPTION
stored user object in command message `_sender` from which you can pass to the new function in `UserManager` called `IsUserAdmin`

Ticket: https://trello.com/c/HquxrCsV/40-implement-sender-ip-retrieval-from-the-live-connection-and-store-it-in-the-commandmessage-class