### PR TITLE
Register users upon receiving their AUTH message

### DIFF
--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -3,7 +3,7 @@ using WebSocketSharp;
 
 namespace Backend.Models.Messages
 {
-    public enum CommandType
+    enum CommandType
     {
         Mute,
         Kick,
@@ -17,12 +17,6 @@ namespace Backend.Models.Messages
     public class CommandMessage : Message
     {
         private CommandType _command;
-        public CommandType CommandType
-        {
-            get { return _command; }
-            set { _command = value; }
-        }
-
         private User? _sender;
         private string? _target;
         private string? _channel;

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -1,8 +1,9 @@
 ﻿using Backend.Models.Users;
+using WebSocketSharp;
 
 namespace Backend.Models.Messages
 {
-    enum CommandType
+    public enum CommandType
     {
         Mute,
         Kick,
@@ -16,6 +17,12 @@ namespace Backend.Models.Messages
     public class CommandMessage : Message
     {
         private CommandType _command;
+        public CommandType CommandType
+        {
+            get { return _command; }
+            set { _command = value; }
+        }
+
         private User? _sender;
         private string? _target;
         private string? _channel;
@@ -63,10 +70,10 @@ namespace Backend.Models.Messages
             }
         }
 
-        public CommandMessage(string rawString) : base(rawString)
+        public CommandMessage(WebSocket socket, string rawString) : base(socket, rawString)
         {
             _command = GetCommandType();
-            _sender = UserManager.GetUserByUsername(_from);
+            _sender = UserManager.GetUserBySocket(socket);
             _target = _to;
             _channel = _in;
             _payload = _with;

--- a/Backend/Models/Messages/Message.cs
+++ b/Backend/Models/Messages/Message.cs
@@ -1,4 +1,6 @@
-﻿namespace Backend.Models.Messages
+﻿using WebSocketSharp;
+
+namespace Backend.Models.Messages
 {
     struct MessageParams
     {
@@ -8,6 +10,7 @@
         public string In = "";
         public long At = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds();
         public string With = "";
+
         public MessageParams(string rawString)
         {
             string[] commandPairs = rawString.Split("\r\n");
@@ -53,18 +56,21 @@
         protected string _in;
         protected long _at;
         protected string _with;
+        protected WebSocket? _socket;
 
         protected Message()
         {
+            // This is needed by EntityFramework
             _do = string.Empty;
             _from = string.Empty;
             _to = string.Empty;
             _in = string.Empty;
             _at = 0;
             _with = string.Empty;
+            _socket = null;
         }
 
-        public Message(string rawString)
+        public Message(WebSocket socket, string rawString)
         {
             MessageParams messageParams = new MessageParams(rawString);
 
@@ -74,6 +80,7 @@
             _in = messageParams.In;
             _at = messageParams.At;
             _with = messageParams.With;
+            _socket = socket;
         }
 
         public static MessageType GetMessageType(string rawString)

--- a/Backend/Models/Messages/TextMessage.cs
+++ b/Backend/Models/Messages/TextMessage.cs
@@ -1,4 +1,5 @@
 ﻿using Backend.Database;
+using WebSocketSharp;
 
 namespace Backend.Models.Messages
 {
@@ -36,13 +37,14 @@ namespace Backend.Models.Messages
 
         private TextMessage()
         {
+            // This is needed by EntityFramework
             _sender = string.Empty;
             _channel = string.Empty;
             _timestamp = 0;
             _content = string.Empty;
         }
 
-        public TextMessage(string rawString) : base(rawString)
+        public TextMessage(WebSocket socket, string rawString) : base(socket, rawString)
         {
             _sender = _from;
             _channel = _in;

--- a/Backend/Models/Users/User.cs
+++ b/Backend/Models/Users/User.cs
@@ -73,5 +73,12 @@ namespace Backend.Models.Users
             context.Add(this);
             context.SaveChanges();
         }
+
+        public static User? GetUserFromDB(string username)
+        {
+            List<User> usersFromDB = context.Users.Where(m => m.Username == username).ToList();
+            if (usersFromDB.Count == 0) return null;
+            return usersFromDB.First();
+        }
     }
 }

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -16,7 +16,6 @@ namespace Backend.Models.Users
         public static void BanIp(string ip)
         { 
             BannedIp ipToBan = new BannedIp(ip);
-
             if (ipToBan.AlreadyExists())
             {
                 Console.WriteLine($"Attempt to ban IP {ip} failed: IP already banned");
@@ -52,7 +51,7 @@ namespace Backend.Models.Users
             User? user = GetUserBySocket(socket);
             if (user == null)
             {
-                Console.WriteLine("Invalid authentication attempt");
+                Console.WriteLine("User is not connected");
                 return false;
             }
 
@@ -62,8 +61,8 @@ namespace Backend.Models.Users
                 return false;
             }
 
-            bool isUserConnected = GetUserByUsername(username) != null;
-            if (isUserConnected)
+            bool isUsernameConnected = GetUserByUsername(username) != null;
+            if (isUsernameConnected)
             {
                 return false;
             }


### PR DESCRIPTION
After a connection is established, users are in a limbo state where they cannot interact with the server until they send an AUTH message providing their usernames.

For this ticket wee need to implement the RegisterUser(socket, username) function in the UserManager and call it from the CommandMessage class. You’ll need to extend the CommandInvoker that should be created from this item: https://trello.com/c/gA3D6gV1/61-command-invoker .
This command does not require any admin permission checks.

Users must be saved in auth instead of connect

The User object must first go through validation checks when authenticating (duplicate usernames, banned users…etc).

(Needed from other ticket) Implement GetUserBySocket() which returns the User object when passing in a specific websocket connection.

[Trello ticket](https://trello.com/c/gO7N1LXa/60-register-users-upon-receiving-their-auth-message)