### PR TITLE
Message reflection

### DIFF
--- a/Backend/Models/Messages/TextMessage.cs
+++ b/Backend/Models/Messages/TextMessage.cs
@@ -1,4 +1,5 @@
 ﻿using Backend.Database;
+using Backend.Models.Users;
 using WebSocketSharp;
 
 namespace Backend.Models.Messages
@@ -46,10 +47,37 @@ namespace Backend.Models.Messages
 
         public TextMessage(WebSocket socket, string rawString) : base(socket, rawString)
         {
-            _sender = _from;
-            _channel = _in;
+            _sender = _from != String.Empty ? _from : UserManager.GetUsernameBySocket(socket);
+            _channel = _in != String.Empty ? _in : "general-chat";
             _timestamp = _at;
             _content = _with;
+        }
+
+        public override string ToString()
+        {
+            string msgString = "DO SEND\r\n";
+
+            if (_sender != String.Empty)
+            {
+                msgString += $"FROM {_sender}\r\n"; 
+            }
+
+            if (_channel != String.Empty)
+            {
+                msgString += $"IN {_channel}\r\n";
+            }
+
+            if (_timestamp != 0)
+            {
+                msgString += $"AT {_timestamp}\r\n";
+            }
+
+            if (_content != String.Empty)
+            {
+                msgString += $"WITH\r\n{_content}";
+            }
+
+            return msgString;
         }
 
         // Persistence

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -81,5 +81,10 @@ namespace Backend.Models.Users
         {
             return UsersList.Find(user => user.Socket == socket);
         }
+
+        public static string GetUsernameBySocket(WebSocket socket)
+        {
+            return GetUserBySocket(socket)?.Username ?? String.Empty;
+        }
     }
 }

--- a/Backend/ServerModules/ServerBehavior.cs
+++ b/Backend/ServerModules/ServerBehavior.cs
@@ -38,7 +38,10 @@ namespace Backend.ServerModules
                         return;
                     }
 
-                    SendToAll(socket, rawString);
+                    var textMessage = new TextMessage(socket, rawString);
+
+                    Console.WriteLine($"{textMessage.Sender}: {textMessage.Content}");
+                    SendToAll(textMessage.ToString());
                     
                     break;
                 case MessageType.CommandMessage:
@@ -64,11 +67,8 @@ namespace Backend.ServerModules
             return UserManager.Authenticate(user.Socket, username);
         }
 
-        private void SendToAll(WebSocket socket, string rawString)
+        private void SendToAll(string message)
         {
-            var textMessage = new TextMessage(socket, rawString);
-            Console.WriteLine($"{textMessage.Sender}: {textMessage.Content}");
-
             foreach (User client in UserManager.UsersList)
             {
                 if (!client.IsRegistered)
@@ -76,7 +76,7 @@ namespace Backend.ServerModules
                     continue;
                 }
 
-                client.Socket.Send(textMessage.ToString());
+                client.Socket.Send(message);
             }
         }
     }


### PR DESCRIPTION
- Made `_sender` and `_channel` properties in `TextMessage` to be auto-filled if not provided in the raw string
- Implemented an overridden `ToString()` method in `TextMessage` to encode a `TextMessage` object in compliance with LSMP
- Implemented a `GetUsernameBySocket()` method in `UserManager` used for auto-filling `_sender` in the previously mentioned point
- `_channel` however is defaulted to `general-chat` every time it is not provided
- Added a validation check in `OnMessage` to prevent muted users from sending messages
- Added a loop that reflects back a sent message to all clients, ignoring the sender itself and any unregistered client

[Trello ticket](https://trello.com/c/T5xk7JcO/84-message-reflection?filter=member:omarkamal28)