### PR TITLE
Find existing users in the DB on connect

### DIFF
--- a/Backend/Models/Users/User.cs
+++ b/Backend/Models/Users/User.cs
@@ -33,6 +33,7 @@ namespace Backend.Models.Users
         }
 
         private bool _isRegistered = false;
+        [NotMapped]
         public bool IsRegistered
         {
             get { return _isRegistered; }
@@ -56,7 +57,7 @@ namespace Backend.Models.Users
         private User()
         {
             // This is needed by EntityFramework
-            _socket = new WebSocket("");
+            _socket = new WebSocket("ws://localhost");
             _ip = String.Empty;
         }
 

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -84,6 +84,11 @@ namespace Backend.Models.Users
             }
             user.IsRegistered = true;
 
+            if (user.IsBanned)
+            {
+                Disconnect(user);
+            }
+
             CLogger.Event($"User authenticated with username: {username}");
             return true;
         }

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -82,7 +82,6 @@ namespace Backend.Models.Users
             {
                 user = userInDb;
             }
-            user.IsRegistered = true;
 
             if (user.IsBanned)
             {
@@ -91,6 +90,7 @@ namespace Backend.Models.Users
                 return false;
             }
 
+            user.IsRegistered = true;
             CLogger.Event($"User authenticated with username: {username}");
             return true;
         }

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -72,9 +72,17 @@ namespace Backend.Models.Users
                 return false;
             }
 
-            user.Username = username;
+            User? userInDb = User.GetUserFromDB(username);
+            if (userInDb == null)
+            {
+                user.Username = username;
+                user.SaveToDb();
+            }
+            else
+            {
+                user = userInDb;
+            }
             user.IsRegistered = true;
-            user.SaveToDb();
 
             CLogger.Event($"User authenticated with username: {username}");
             return true;

--- a/Backend/Models/Users/UserManager.cs
+++ b/Backend/Models/Users/UserManager.cs
@@ -87,6 +87,8 @@ namespace Backend.Models.Users
             if (user.IsBanned)
             {
                 Disconnect(user);
+                CLogger.Error($"Connection refused from banned user: {user.Username}");
+                return false;
             }
 
             CLogger.Event($"User authenticated with username: {username}");


### PR DESCRIPTION
- Server now checks if the auth username already exists in DB and loads its data
- If the user is banned, Disconnect() is called on the user, however Disconnect() is not yet implemented
- Made User.IsRegistered not mapped to DB (because it's unique to each session)

[Trello ticket](https://trello.com/c/m6C5uvUe/87-find-existing-users-in-the-db-on-connect)