### PR TITLE
Implement sending the message history of a channel to clients

### DIFF
--- a/Backend/Database/Database.cs
+++ b/Backend/Database/Database.cs
@@ -53,7 +53,7 @@ namespace Backend.Database
         {
             BannedIpContext bannedIpContext = new BannedIpContext();
             // This vvv should be disabled in prod
-            // userContext.Database.EnsureDeleted();
+            // bannedIpContext.Database.EnsureDeleted();
             bannedIpContext.Database.EnsureCreated();
         }
     }

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -136,15 +136,12 @@ namespace Backend.Models.Messages
         }
         private void ProcessRemember()
         {
-            int param1, param2;
-            if (!int.TryParse(_from, out param1) || !int.TryParse(_to, out param2))
+            int fromId, toId;
+            if (!int.TryParse(_from, out fromId) || !int.TryParse(_to, out toId))
             {
                 SendRefuse("Invalid limits provided");
                 return;
             }
-
-            int fromId = Math.Min(param1, param2);
-            int toId = Math.Max(param1, param2);
 
             string channel = "general-chat";
             if (_in != string.Empty)

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -77,7 +77,7 @@ namespace Backend.Models.Messages
                 case CommandType.Unbanip:
                     break;
                 case CommandType.Remember:
-                    SendMessageHistory();
+                    ProcessRemember();
                     break;
                 case CommandType.Unknown:
                     break;
@@ -134,7 +134,7 @@ namespace Backend.Models.Messages
             SendAccept();
             CLogger.Event("User Muted: " + _target);
         }
-        private void SendMessageHistory()
+        private void ProcessRemember()
         {
             int param1, param2;
             if (!int.TryParse(_from, out param1) || !int.TryParse(_to, out param2))

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -151,7 +151,14 @@ namespace Backend.Models.Messages
 
             List<TextMessage> messageHistory = TextMessage.GetMessageHistory(channel, fromId, toId);
 
-            // TODO
+            string msgString = "DO POPULATE\r\nWITH\r\n";
+            string msgArray = LSMPBehavior.EncodeArrayToString(messageHistory);
+            msgString += msgArray;
+
+            if (_sender != null)
+            {
+                _sender.Socket.Send(msgString);
+            }
         }
     }
 

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -136,12 +136,15 @@ namespace Backend.Models.Messages
         }
         private void SendMessageHistory()
         {
-            int fromId, toId;
-            if (!int.TryParse(_from, out fromId) || !int.TryParse(_to, out toId))
+            int param1, param2;
+            if (!int.TryParse(_from, out param1) || !int.TryParse(_to, out param2))
             {
                 SendRefuse("Invalid limits provided");
                 return;
             }
+
+            int fromId = Math.Min(param1, param2);
+            int toId = Math.Max(param1, param2);
 
             string channel = "general-chat";
             if (_in != string.Empty)

--- a/Backend/Models/Messages/CommandMessage.cs
+++ b/Backend/Models/Messages/CommandMessage.cs
@@ -1,4 +1,5 @@
 ﻿using Backend.Models.Users;
+using Backend.ServerModules;
 using Backend.Utils;
 using WebSocketSharp;
 
@@ -16,6 +17,7 @@ namespace Backend.Models.Messages
             Ipban,
             Unban,
             Unbanip,
+            Remember,
             Unknown
         }
 
@@ -50,6 +52,8 @@ namespace Backend.Models.Messages
                     return CommandType.Unban;
                 case "unbanip":
                     return CommandType.Unbanip;
+                case "remember":
+                    return CommandType.Remember;
                 default:
                     return CommandType.Unknown;
             }
@@ -71,6 +75,9 @@ namespace Backend.Models.Messages
                 case CommandType.Unban:
                     break;
                 case CommandType.Unbanip:
+                    break;
+                case CommandType.Remember:
+                    SendMessageHistory();
                     break;
                 case CommandType.Unknown:
                     break;
@@ -127,5 +134,25 @@ namespace Backend.Models.Messages
             SendAccept();
             CLogger.Event("User Muted: " + _target);
         }
+        private void SendMessageHistory()
+        {
+            int fromId, toId;
+            if (!int.TryParse(_from, out fromId) || !int.TryParse(_to, out toId))
+            {
+                SendRefuse("Invalid limits provided");
+                return;
+            }
+
+            string channel = "general-chat";
+            if (_in != string.Empty)
+            {
+                channel = _in;
+            }
+
+            List<TextMessage> messageHistory = TextMessage.GetMessageHistory(channel, fromId, toId);
+
+            // TODO
+        }
     }
+
 }

--- a/Backend/Models/Messages/TextMessage.cs
+++ b/Backend/Models/Messages/TextMessage.cs
@@ -53,7 +53,13 @@ namespace Backend.Models.Messages
             {
                 _sender = UserManager.GetUsernameBySocket(socket);
             }
-            _channel = _in;
+
+            _channel = "general-chat";
+            if (_in != string.Empty)
+            {
+                _channel = _in;
+            }
+
             _timestamp = _at;
             _content = _with;
         }
@@ -97,7 +103,7 @@ namespace Backend.Models.Messages
         public static List<TextMessage> GetMessageHistory(string channel, int from, int to)
         {
             List<TextMessage> messageHistory = context.TextMessages
-                .Where(m => m.TextMessageId < from && m.TextMessageId >= to)
+                .Where(m => m.TextMessageId >= from && m.TextMessageId < to && m.Channel == channel)
                 .ToList();
 
             return messageHistory;

--- a/Backend/ServerModules/ServerBehavior.cs
+++ b/Backend/ServerModules/ServerBehavior.cs
@@ -67,6 +67,7 @@ namespace Backend.ServerModules
                     var textMessage = new TextMessage(socket, rawString);
 
                     SendToAll(textMessage);
+                    textMessage.SaveToDb();
                     CLogger.Chat(textMessage.Sender, textMessage.Content);
                     break;
                 case MessageType.CommandMessage:


### PR DESCRIPTION
- Added the `REMEMBER` server command
- The command responds by sending the message history within the specified limits

[Trello ticket](https://trello.com/c/x9SFVH1P/95-implement-sending-the-message-history-of-a-channel-to-clients)