### PR TITLE
Cleanse username on Auth

### DIFF
--- a/Backend/ServerModules/ServerBehavior.cs
+++ b/Backend/ServerModules/ServerBehavior.cs
@@ -26,6 +26,7 @@ namespace Backend.ServerModules
                 if (IsAuthRequest(rawString))
                 {
                     string username = rawString.Substring(14);
+                    username = username.Trim();
                     if (UserManager.Authenticate(user.Socket, username))
                     {
                         SendAccept();


### PR DESCRIPTION
- Trimmed username using String.Trim(); to get rid of whitespace characters (spaces, newlines...etc)

[Trello ticket](https://trello.com/c/h6OgsKq7/102-cleanse-username-on-auth)